### PR TITLE
fix null foreach when parameters is not set

### DIFF
--- a/src/FastFeed/Url/Url.php
+++ b/src/FastFeed/Url/Url.php
@@ -195,7 +195,7 @@ class Url
     {
         return
             ($this->getPath() ? $this->getPath() : '') .
-            ($this->getQuery() ? '?' . $this->getQuery() : '') .
+            ($this->getParameters() ? '?' . $this->getQuery() : '') .
             ($this->getFragment() ? '#' . $this->getFragment() : '');
     }
 


### PR DESCRIPTION
getQuery method don't check iff the parameters var is set, so an exception is launched when calling getFullPath and base url don't have any query string.
