### PR TITLE
Fixed and improved around query parameters

### DIFF
--- a/src/FastFeed/Url/Url.php
+++ b/src/FastFeed/Url/Url.php
@@ -128,13 +128,18 @@ class Url
     }
 
     /**
-     * @param string $parameter
-     *
+     * @param string      $parameter
+     * @param string|null $defaultValue
      * @return string
      */
-    public function getParameter($parameter)
+    public function getParameter($parameter, $defaultValue = null)
     {
-        return $this->parameters[(string)$parameter];
+        $key = (string)$parameter;
+        if (array_key_exists($key, $this->parameters)) {
+            return $this->parameters[$key];
+        } else {
+            return $defaultValue;
+        }
     }
 
     /**

--- a/src/FastFeed/Url/Url.php
+++ b/src/FastFeed/Url/Url.php
@@ -65,11 +65,7 @@ class Url
             }
         }
         if (isset($parsed['query'])) {
-            $items = explode('&', $parsed['query']);
-            foreach ($items as $item) {
-                $value = explode('=', $item);
-                $this->parameters[(string)$value[0]] = (string)$value[1];
-            }
+            parse_str($parsed['query'], $this->parameters);
         } else {
             $this->resetParameters();
         }
@@ -174,12 +170,7 @@ class Url
      */
     public function getQuery()
     {
-        $query = '';
-        foreach ($this->parameters as $parameter => $value) {
-            $query .= '&' . $parameter . '=' . $value;
-        }
-
-        return substr($query, 1);
+        return http_build_query($this->parameters);
     }
 
     /**

--- a/src/FastFeed/Url/Url.php
+++ b/src/FastFeed/Url/Url.php
@@ -70,6 +70,8 @@ class Url
                 $value = explode('=', $item);
                 $this->parameters[(string)$value[0]] = (string)$value[1];
             }
+        } else {
+            $this->resetParameters();
         }
     }
 

--- a/tests/FastFeed/Url/UrlTest.php
+++ b/tests/FastFeed/Url/UrlTest.php
@@ -124,6 +124,28 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param $url
+     * @param $expectedParameters
+     *
+     * @dataProvider dataProviderForTestGetParameters
+     */
+    public function testGetParameters($url, $expectedParameters)
+    {
+        $url = new Url($url);
+        $this->assertEquals($expectedParameters, $url->getParameters());
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestGetParameters()
+    {
+        return array(
+            array('https://google.com', array()),
+        );
+    }
+
+    /**
+     * @param $url
      * @param $expectedFragment
      *
      * @dataProvider dataProviderForTestGetFragment

--- a/tests/FastFeed/Url/UrlTest.php
+++ b/tests/FastFeed/Url/UrlTest.php
@@ -132,6 +132,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         $url = new Url($url);
         $this->assertEquals($expectedParameters, $url->getParameters());
+        $this->assertEquals($url, $url->toString());
     }
 
     /**
@@ -141,6 +142,30 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('https://google.com', array()),
+            array('https://google.com?q=yahoo%2finfoseek&v=1', array('q' => 'yahoo/infoseek', 'v' => '1')),
+        );
+    }
+
+    /**
+     * @param $url
+     * @param $key
+     * @param $expectedValue
+     *
+     * @dataProvider dataProviderForTestGetParameter
+     */
+    public function testGetParameter($url, $key, $expectedValue)
+    {
+        $url = new Url($url);
+        $this->assertEquals($expectedValue, $url->getParameter($key));
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestGetParameter()
+    {
+        return array(
+            array('https://google.com?q=yahoo%2finfoseek', 'q', 'yahoo/infoseek'),
         );
     }
 

--- a/tests/FastFeed/Url/UrlTest.php
+++ b/tests/FastFeed/Url/UrlTest.php
@@ -149,14 +149,19 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     /**
      * @param $url
      * @param $key
+     * @param $defaultValue
      * @param $expectedValue
      *
      * @dataProvider dataProviderForTestGetParameter
      */
-    public function testGetParameter($url, $key, $expectedValue)
+    public function testGetParameter($url, $key, $defaultValue, $expectedValue)
     {
         $url = new Url($url);
-        $this->assertEquals($expectedValue, $url->getParameter($key));
+        if ($defaultValue) {
+            $this->assertEquals($expectedValue, $url->getParameter($key, $defaultValue));
+        } else {
+            $this->assertEquals($expectedValue, $url->getParameter($key));
+        }
     }
 
     /**
@@ -165,7 +170,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     public function dataProviderForTestGetParameter()
     {
         return array(
-            array('https://google.com?q=yahoo%2finfoseek', 'q', 'yahoo/infoseek'),
+            array('https://google.com', 'q', null, null),
+            array('https://google.com?r=1', 'q', 's', 's'),
+            array('https://google.com?q=yahoo%2finfoseek', 'q', 's', 'yahoo/infoseek'),
         );
     }
 


### PR DESCRIPTION
Hi,

There ware some issues around query parameters, like:
- `Url` class did not care of url encoded string.
- `getParameters()` did return `null` (instead of array) if there was no query parameters.
- `getParameter()` did possibly cause PHP's warning if specified parameter did not exist.

So I made some patches. It also includes an additional feature.
- added `$defaultValue` parameter to `getParameter()`.
